### PR TITLE
Fix padding issue with gravatar

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@ article {
 
   display: block;
   margin: 0 auto;
-  padding-bottom: 15px;
+  margin-bottom: 15px;
 }
 
 .icon img {


### PR DESCRIPTION
Using `padding-bottom: 15px;` on your Gravatar image ends up turning your
picture into a weird egg shape:

![](http://cdn.davidcel.is/screens/Screen-Shot-2015-10-09-at-4.24.30-PM.png)

Changing it to a margin fixes this:

![](http://cdn.davidcel.is/screens/Screen-Shot-2015-10-09-at-4.25.31-PM.png)